### PR TITLE
Broaden PHP VCR requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "~3.0",
-        "php-vcr/php-vcr": "~1.2.4"
+        "php-vcr/php-vcr": "~1.4"
     },
     "autoload": {
         "psr-4" : {


### PR DESCRIPTION
This PR loosen the requirements from `~1.2.4` to `~1.4`.

As PHP VCR uses semver, this hsould be safe. Also I used it on my project without issues :)